### PR TITLE
Feature/add 30 day reminder

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,9 +6,9 @@ from explainbot_pipeline_stack import ExplainSlackBotPipelineStack
 explainbot_account=cdk.SecretValue.secrets_manager('EXPLAINBOT_ACCOUNT').to_string()
 
 app = cdk.App()
-ExplainSlackBotPipelineStack(app, "ExplainBotPipelineStack", env={
+ExplainSlackBotPipelineStack(app, "ExplainBotPipelineStackEast2", env={
     'account': explainbot_account,
-    'region': 'us-east-1'
+    'region': 'us-east-2'
 })
 
 app.synth()

--- a/app.py
+++ b/app.py
@@ -2,13 +2,16 @@
 from aws_cdk import core as cdk
 
 from explainbot_pipeline_stack import ExplainSlackBotPipelineStack
+from explainbot_stack import ExplainSlackBotStack
 
 explainbot_account=cdk.SecretValue.secrets_manager('EXPLAINBOT_ACCOUNT').to_string()
 
 app = cdk.App()
-ExplainSlackBotPipelineStack(app, "ExplainBotPipelineStackEast2", env={
+
+ExplainSlackBotStack(app, "ExplainBotStack")
+ExplainSlackBotPipelineStack(app, "ExplainBotPipelineStack", env={
     'account': explainbot_account,
-    'region': 'us-east-2'
+    'region': 'us-east-1'
 })
 
 app.synth()

--- a/app.py
+++ b/app.py
@@ -2,13 +2,10 @@
 from aws_cdk import core as cdk
 
 from explainbot_pipeline_stack import ExplainSlackBotPipelineStack
-from explainbot_stack import ExplainSlackBotStack
 
 explainbot_account=cdk.SecretValue.secrets_manager('EXPLAINBOT_ACCOUNT').to_string()
 
 app = cdk.App()
-
-ExplainSlackBotStack(app, "ExplainBotStack")
 ExplainSlackBotPipelineStack(app, "ExplainBotPipelineStack", env={
     'account': explainbot_account,
     'region': 'us-east-1'

--- a/explainbot_pipeline_stack.py
+++ b/explainbot_pipeline_stack.py
@@ -39,9 +39,7 @@ class ExplainSlackBotPipelineStack(cdk.Stack):
             )
         )
 
-        """
         pipeline.add_application_stage(ExplainSlackBotStage(self, 'PreProd', env={
             'account': explainbot_account,
             'region': 'us-east-1'
         }))
-        """

--- a/explainbot_pipeline_stack.py
+++ b/explainbot_pipeline_stack.py
@@ -40,5 +40,5 @@ class ExplainSlackBotPipelineStack(cdk.Stack):
         )
         pipeline.add_application_stage(ExplainSlackBotStage(self, 'PreProd', env={
             'account': explainbot_account,
-            'region': 'us-east-1'
+            'region': 'us-east-2'
         }))

--- a/explainbot_pipeline_stack.py
+++ b/explainbot_pipeline_stack.py
@@ -28,7 +28,7 @@ class ExplainSlackBotPipelineStack(cdk.Stack):
                 oauth_token=cdk.SecretValue.secrets_manager('GITHUB_TOKEN_NAME'),
                 owner='blackboard-innersource',
                 repo='explain-bot',
-                branch='feature/add_pipeline',
+                branch='feature/add-30-day-reminder',
                 trigger=cpactions.GitHubTrigger.POLL
             ),
             synth_action=SimpleSynthAction(

--- a/explainbot_pipeline_stack.py
+++ b/explainbot_pipeline_stack.py
@@ -38,7 +38,10 @@ class ExplainSlackBotPipelineStack(cdk.Stack):
                     synth_command='cdk synth'
             )
         )
+
+        """
         pipeline.add_application_stage(ExplainSlackBotStage(self, 'PreProd', env={
             'account': explainbot_account,
-            'region': 'us-east-2'
+            'region': 'us-east-1'
         }))
+        """

--- a/explainbot_stack.py
+++ b/explainbot_stack.py
@@ -184,6 +184,7 @@ class ExplainBotCloudWatchStack(cdk.Stack):
             **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
+        # Change to cdk.Duration.days(1)
         lambda_schedule = _events.Schedule.rate(cdk.Duration.minutes(1))
 
         reminder_lambda = _lambda.Function(

--- a/explainbot_stack.py
+++ b/explainbot_stack.py
@@ -114,6 +114,10 @@ class ExplainBotDatabaseStack(cdk.Stack):
             removal_policy=cdk.RemovalPolicy.DESTROY
         )
 
+        acronym_table.add_global_secondary_index( 
+           partition_key=Attribute(name='Approval', type=_dynamo.AttributeType.STRING),
+           index_name='approval_index')
+
         self.table = acronym_table
 
         # Add the table name as an environment variable
@@ -197,7 +201,7 @@ class ExplainBotCloudWatchStack(cdk.Stack):
         )
 
         table.grant_full_access(reminder_lambda)
-        
+
         event_lambda_target = _events_targets.LambdaFunction(handler = reminder_lambda)
         lambda_cw_event = _events.Rule(self, "SendReminders",
             description = "Once per day CW event trigger for lambda",

--- a/explainbot_stack.py
+++ b/explainbot_stack.py
@@ -184,8 +184,7 @@ class ExplainBotCloudWatchStack(cdk.Stack):
             **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
-        # Change to cdk.Duration.days(1)
-        lambda_schedule = _events.Schedule.rate(cdk.Duration.minutes(1))
+        lambda_schedule = _events.Schedule.rate(cdk.Duration.days(1))
 
         reminder_lambda = _lambda.Function(
             self, "SendReminderHandler",

--- a/explainbot_stack.py
+++ b/explainbot_stack.py
@@ -115,7 +115,7 @@ class ExplainBotDatabaseStack(cdk.Stack):
         )
 
         acronym_table.add_global_secondary_index( 
-           partition_key=Attribute(name='Approval', type=_dynamo.AttributeType.STRING),
+           partition_key=_dynamo.Attribute(name='Approval', type=_dynamo.AttributeType.STRING),
            index_name='approval_index')
 
         self.table = acronym_table

--- a/lambda/add_meaning.py
+++ b/lambda/add_meaning.py
@@ -11,6 +11,7 @@ from botocore.exceptions import ClientError
 from boto3.dynamodb.conditions import Key
 import urllib3
 from datetime import datetime
+from datetime import date
 
 # Get the service resource.
 dynamodb = boto3.resource('dynamodb')
@@ -61,7 +62,7 @@ def define(acronym, definition, meaning, notes, response_url, user_id, user_name
             REQUESTER_STR: user_id,
             'RequesterName': user_name,
             APPROVAL_STR: APPROVAL_STATUS_PENDING,
-            REQUEST_TIMESTAMP : datetime.utcnow().timestamp(),
+            REQUEST_TIMESTAMP : int(datetime.utcnow().timestamp()),
             'TeamDomain' : team_domain
         }
     )
@@ -370,7 +371,8 @@ def lambda_handler(event, context):
     # Define acronym (persist in DB) and send approval request to approvers
     return_url = payload['response_urls'][0]['response_url']
     
-    status_code = define(acronym,definition,meaning,notes,return_url,user_id,user_name,team_domain)
+    user_name_capitalized = " ".join(user_name)
+    status_code = define(acronym,definition,meaning,notes,return_url,user_id,user_name_capitalized,team_domain)
     create_approval_request(acronym,definition,meaning,notes,team_domain,user_id,user_name)
     notify_pending_approval(user_id,acronym)
     

--- a/lambda/add_meaning.py
+++ b/lambda/add_meaning.py
@@ -202,6 +202,7 @@ def create_approval_request(acronym, definition, meaning, notes, team_domain, us
 
             if data.get('ok'):
                 message_data = {
+                    'approver': approver,
                     'channel': data.get('channel'),
                     'ts': data.get('ts')
                 }

--- a/lambda/add_meaning.py
+++ b/lambda/add_meaning.py
@@ -10,7 +10,7 @@ import boto3
 from botocore.exceptions import ClientError
 from boto3.dynamodb.conditions import Key
 import urllib3
-from datetime import date
+from datetime import datetime
 
 # Get the service resource.
 dynamodb = boto3.resource('dynamodb')
@@ -25,6 +25,8 @@ REQUESTER_STR = 'Requester'
 APPROVAL_STR = 'Approval'
 APPROVAL_STATUS_PENDING = 'pending'
 APPROVAL_STATUS_APPROVED = 'approved'
+REQUEST_TIMESTAMP = 'RequestTimestamp'
+SENT_REMINDERS = 'Reminders'
 REVIEWERS_MAX = 3
 
 table = dynamodb.Table(TABLE_NAME)
@@ -58,7 +60,9 @@ def define(acronym, definition, meaning, notes, response_url, user_id):
             'Meaning': meaning,
             'Notes': notes,
             REQUESTER_STR: user_id,
-            APPROVAL_STR: APPROVAL_STATUS_PENDING
+            APPROVAL_STR: APPROVAL_STATUS_PENDING,
+            REQUEST_TIMESTAMP = datetime.utcnow().timestamp(),
+            SENT_REMINDERS = 0
         }
     )
 
@@ -506,7 +510,7 @@ def check_hash(event):
     digestmod=hashlib.sha256
   ).hexdigest()
   print("Generated signature: " + my_signature)
-  
+
   slack_signature = event['headers']['x-slack-signature']
   print("Slack signature: " + slack_signature)
 

--- a/lambda/add_meaning.py
+++ b/lambda/add_meaning.py
@@ -61,8 +61,8 @@ def define(acronym, definition, meaning, notes, response_url, user_id, user_name
             REQUESTER_STR: user_id,
             'RequesterName': user_name,
             APPROVAL_STR: APPROVAL_STATUS_PENDING,
-            REQUEST_TIMESTAMP = datetime.utcnow().timestamp(),
-            'TeamDomain' = team_domain
+            REQUEST_TIMESTAMP : datetime.utcnow().timestamp(),
+            'TeamDomain' : team_domain
         }
     )
 

--- a/lambda/add_meaning.py
+++ b/lambda/add_meaning.py
@@ -169,7 +169,7 @@ def get_approval_form(acronym, definition, meaning, notes, team_domain, user_id,
                 "ts": ts if update == True else None
             }
 
-def create_approval_request(acronym, definition, meaning, notes, team_domain, user_id, user_name):
+def create_approval_request(acronym, definition, meaning, notes, team_domain, user_id, user_name, approvers):
 
     user_name_capitalized = " ".join(user_name)
     date_requested = date.today().strftime("%d/%m/%Y")
@@ -178,7 +178,7 @@ def create_approval_request(acronym, definition, meaning, notes, team_domain, us
     if meaning is "":
         meaning = "-"
 
-    for approver in APPROVERS:
+    for approver in approvers:
         if approver != user_id:
 
             #Send approval request
@@ -373,7 +373,7 @@ def lambda_handler(event, context):
     
     user_name_capitalized = " ".join(user_name)
     status_code = define(acronym,definition,meaning,notes,return_url,user_id,user_name_capitalized,team_domain)
-    create_approval_request(acronym,definition,meaning,notes,team_domain,user_id,user_name)
+    create_approval_request(acronym,definition,meaning,notes,team_domain,user_id,user_name, APPROVERS)
     notify_pending_approval(user_id,acronym)
     
     return {
@@ -383,8 +383,8 @@ def lambda_handler(event, context):
 def update_form_closed(item):
     try:
         approvers_message_list = item['ApproverMessages']
-
-        for item in approvers_message_list:
+        acronym = item['Acronym']
+        for reg in approvers_message_list:
             modal = {
                 "blocks": [
                     {
@@ -395,8 +395,8 @@ def update_form_closed(item):
                         }
                     }
                 ],
-                "channel": item['channel'],
-                "ts": item['ts']
+                "channel": reg['channel'],
+                "ts": reg['ts']
             }
 
             headers = {

--- a/lambda/send_reminder.py
+++ b/lambda/send_reminder.py
@@ -185,10 +185,11 @@ def create_approval_request(acronym, definition, meaning, notes, team_domain, us
 
 def lambda_handler(event, context):
 
-    results = table.query(KeyConditionExpression=Key("Approval").eq('pending'))
+    print('SEND REMINDER HANDLER')
+    results = table.query(IndexName="approval_index", KeyConditionExpression=Key("Approval").eq('pending'))
     if len(results['Items']) > 0:
         items = results['Items']
-
+        print(items)
         for item in items:
             request_time = item.get(REQUEST_TIMESTAMP)//TO_MINUTES
             current_time = datetime.utcnow().timestamp()//TO_MINUTES

--- a/lambda/send_reminder.py
+++ b/lambda/send_reminder.py
@@ -10,7 +10,6 @@ from datetime import date
 from add_meaning import update_form_closed, get_approval_form
 
 
-
 http = urllib3.PoolManager()
 # Get the service resource.
 dynamodb = boto3.resource('dynamodb')
@@ -21,7 +20,6 @@ OAUTH_TOKEN = os.environ['OAUTH_TOKEN']
 
 TO_MINUTES = 60
 REQUEST_TIMESTAMP = 'RequestTimestamp'
-SENT_REMINDERS = 'Reminders'
 APPROVERS_STR = 'Approvers'
 DENIERS_STR = 'Deniers'
 

--- a/lambda/send_reminder.py
+++ b/lambda/send_reminder.py
@@ -6,13 +6,179 @@ from datetime import datetime
 dynamodb = boto3.resource('dynamodb')
 table_name = os.environ['TABLE_NAME']
 table = dynamodb.Table(table_name)
+APPROVERS = os.environ['APPROVERS'].split(',')
+OAUTH_TOKEN = os.environ['OAUTH_TOKEN']
 
 TO_MINUTES = 1000*60
 REQUEST_TIMESTAMP = 'RequestTimestamp'
 SENT_REMINDERS = 'Reminders'
+APPROVERS_STR = 'Approvers'
+DENIERS_STR = 'Deniers'
 
-def send_reminder(event):
-    return
+
+def update_form_closed(item):
+    try:
+        approvers_message_list = item['ApproverMessages']
+
+        for item in approvers_message_list:
+            modal = {
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "*The request for: " + acronym + " is completed. Thanks for contributing, the voting is closed!*\n"
+                        }
+                    }
+                ],
+                "channel": item['channel'],
+                "ts": item['ts']
+            }
+
+            headers = {
+                'Content-Type': 'application/json',
+                'Authorization': 'Bearer ' + OAUTH_TOKEN
+            }
+            print("headers: " + str(headers))
+
+            response = http.request('POST', 'https://slack.com/api/chat.update', body=json.dumps(modal), headers=headers)
+            print("response: " + str(response.status) + " " + str(response.data))
+    except:
+        print( "Error")
+
+def send_reminder(acronym, definition, meaning, notes, user_id, user_name, team_domain, approvers_with_answer, delete):
+    approvers_missing = [approver for approver in approvers_with_answer if item not in APPROVERS ]
+    create_approval_request(acronym, definition, meaning, notes, team_domain, user_id, user_name, approvers_missing)
+    if delete:
+        response = table.delete_item(
+                Key={
+                    'Acronym': acronym
+                }
+        )
+        # update_form_closed()
+
+def get_approval_form(acronym, definition, meaning, notes, team_domain, user_id, user_name, date_requested, approver, ts, update):
+    return {
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "*You have a new request:*\n<https://" + team_domain + ".slack.com/team/" + user_id + "|" + user_name + " - New acronym request>"
+                        }
+                    },
+                    {
+                        "type": "section",
+                        "fields": [
+                            {
+                                "type": "mrkdwn",
+                                "text": "*Acronym:*\n " + acronym
+                            },
+                            {
+                                "type": "mrkdwn",
+                                "text": "*When:*\nSubmitted " + date_requested
+                            },
+                            {
+                                "type": "mrkdwn",
+                                "text": "*Definition:*\n" + definition
+                            },
+                            {
+                                "type": "mrkdwn",
+                                "text": "*Meaning:*\n" + meaning
+                            }
+                        ]
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "*Notes:*\n" + notes
+                        }
+                    },
+                    {
+                        "type": "divider"
+                    },
+                    {
+                        "type": "actions",
+                        "elements": [
+                            {
+                                "type": "button",
+                                "text": {
+                                    "type": "plain_text",
+                                    "emoji": True,
+                                    "text": "Approve"
+                                },
+                                "style": "primary",
+                                "value": "Approve"
+                            },
+                            {
+                                "type": "button",
+                                "text": {
+                                    "type": "plain_text",
+                                    "emoji": True,
+                                    "text": "Deny"
+                                },
+                                "style": "danger",
+                                "value": "Deny"
+                            }
+                        ]
+                    } if update == False else 
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": ":white_check_mark: *Your choice has been saved successfully!*\n"
+                        }
+                    }
+                ],
+                "channel": approver,
+                "ts": ts if update == True else None
+            }
+
+def create_approval_request(acronym, definition, meaning, notes, team_domain, user_id, user_name, approvers):
+
+    user_name_capitalized = " ".join(user_name)
+    date_requested = date.today().strftime("%d/%m/%Y")
+    approver_messages = []
+
+    if meaning is "":
+        meaning = "-"
+
+    for approver in approvers:
+        if approver != user_id:
+
+            #Send approval request
+            modal = get_approval_form(acronym, definition, meaning, notes, team_domain, user_id, user_name_capitalized, date_requested, approver, None, False)
+
+            headers = {
+                'Content-Type': 'application/json',
+                'Authorization': 'Bearer ' + OAUTH_TOKEN
+            }
+            print("headers: " + str(headers))
+
+            response = http.request('POST', 'https://slack.com/api/chat.postMessage', body=json.dumps(modal), headers=headers)
+            print("response: " + str(response.status) + " " + str(response.data))
+
+            data = json.loads(response.data.decode('utf-8'))
+
+            if data.get('ok'):
+                message_data = {
+                    'channel': data.get('channel'),
+                    'ts': data.get('ts')
+                }
+                approver_messages.append(message_data)
+
+        else:
+            print("Skip approver due to approver sent acronym request")
+
+    table.update_item(
+        Key={
+            'Acronym': acronym
+        },
+        UpdateExpression=f"set ApproverMessages=:a",
+        ExpressionAttributeValues={
+            ':a': approver_messages,
+        },
 
 def lambda_handler(event, context):
 
@@ -21,12 +187,24 @@ def lambda_handler(event, context):
     items = results['Items']
 
     for item in items:
-        print(item.get('Acronym'))
-        request_time = item.get(REQUEST_TIMESTAMP)/TO_MINUTES
-        current_time = datetime.utcnow().timestamp()/TO_MINUTES
+        request_time = item.get(REQUEST_TIMESTAMP)//TO_MINUTES
+        current_time = datetime.utcnow().timestamp()//TO_MINUTES
+        diff_time  = current_time - request_time
 
-        """
-        if current_time - request_time > 10 and item.get(SENT_REMINDERS) == 0:
-            send_reminder()
-        """
+        acronym = item.get('Acronym')
+        print(acronym)
+        definition = item.get('Definition')
+        meaning = item.get('Meaning')
+        notes = item.get('Notes')
+        user_id = item.get('Requester')
+        user_name = item.get('RequesterName')
+        team_domain = item.get('TeamDomain')
+        approvers_with_answer = item.get(APPROVERS_STR, []) + item.get(DENIERS_STR, [])
+
+        if diff_time == 5:
+            send_reminder(acronym, definition, meaning, notes, user_id, user_name, team_domain, approvers_with_answer, False)
+        elif diff_time == 10:
+            send_reminder(acronym, definition, meaning, notes, user_id, user_name, team_domain, approvers_with_answer, True)
+        else:
+            print('Should have been deleted')
 

--- a/lambda/send_reminder.py
+++ b/lambda/send_reminder.py
@@ -48,6 +48,7 @@ def update_form_closed(item):
         print( "Error")
 
 def send_reminder(acronym, definition, meaning, notes, user_id, user_name, team_domain, approvers_with_answer, delete):
+    print('Got to send reminder')
     approvers_missing = [approver for approver in approvers_with_answer if item not in APPROVERS ]
     create_approval_request(acronym, definition, meaning, notes, team_domain, user_id, user_name, approvers_missing)
     if delete:
@@ -191,9 +192,15 @@ def lambda_handler(event, context):
         items = results['Items']
         print(items)
         for item in items:
-            request_time = item.get(REQUEST_TIMESTAMP)//TO_MINUTES
-            current_time = datetime.utcnow().timestamp()//TO_MINUTES
+            request_time = int(item.get(REQUEST_TIMESTAMP))//TO_MINUTES
+            print('RequestTime: ')
+            print(request_time)
+            current_time = int(datetime.utcnow().timestamp())//TO_MINUTES
+            print('CurrentTime: ')
+            print(current_time)
             diff_time  = current_time - request_time
+            print('Diff time')
+            print(diff_time)
 
             acronym = item.get('Acronym')
             print(acronym)
@@ -209,6 +216,4 @@ def lambda_handler(event, context):
                 send_reminder(acronym, definition, meaning, notes, user_id, user_name, team_domain, approvers_with_answer, False)
             elif diff_time == 10:
                 send_reminder(acronym, definition, meaning, notes, user_id, user_name, team_domain, approvers_with_answer, True)
-            else:
-                print('Should have been deleted')
 

--- a/lambda/send_reminder.py
+++ b/lambda/send_reminder.py
@@ -18,93 +18,69 @@ table = dynamodb.Table(table_name)
 APPROVERS = os.environ['APPROVERS'].split(',')
 OAUTH_TOKEN = os.environ['OAUTH_TOKEN']
 
-# Change to TO_DAYS = 60*60*24
-TO_MINUTES = 60
+TO_DAYS = 60*60*24
 REQUEST_TIMESTAMP = 'RequestTimestamp'
 APPROVERS_STR = 'Approvers'
 DENIERS_STR = 'Deniers'
 
 
-def send_reminder(acronym, definition, meaning, notes, user_id, user_name, team_domain, approvers_with_answer):
+def send_reminder(item):
+    approvers_with_answer = item.get(APPROVERS_STR, []) + item.get(DENIERS_STR, [])
     approvers_missing = [approver for approver in APPROVERS if approver not in approvers_with_answer ]
-    print(approvers_missing)
-    create_approval_request(acronym, definition, meaning, notes, team_domain, user_id, user_name, approvers_missing)
+    approver_messages = item['ApproverMessages']
+    team_domain = item['TeamDomain']
+    acronym = item['Acronym']
 
-def create_approval_request(acronym, definition, meaning, notes, team_domain, user_id, user_name, approvers):
-
-    user_name_capitalized = " ".join(user_name)
-    date_requested = date.today().strftime("%d/%m/%Y")
-    approver_messages = []
-
-    if meaning is "":
-        meaning = "-"
-
-    for approver in approvers:
-        if approver == user_id:
-
-            #Send approval request
-            modal = get_approval_form(acronym, definition, meaning, notes, team_domain, user_id, user_name_capitalized, date_requested, approver, None, False)
-
+    for message in approver_messages:
+        approver = message['approver']
+        if approver in approvers_missing:
+            channel = message['channel']
+            ts = message['ts']
+            block = get_reminder_block(acronym, team_domain,approver, channel,ts)
             headers = {
                 'Content-Type': 'application/json',
                 'Authorization': 'Bearer ' + OAUTH_TOKEN
             }
             print("headers: " + str(headers))
 
-            response = http.request('POST', 'https://slack.com/api/chat.postMessage', body=json.dumps(modal), headers=headers)
+            response = http.request('POST', 'https://slack.com/api/chat.postMessage', body=json.dumps(block), headers=headers)
             print("response: " + str(response.status) + " " + str(response.data))
-
-            data = json.loads(response.data.decode('utf-8'))
-
-            if data.get('ok'):
-                message_data = {
-                    'channel': data.get('channel'),
-                    'ts': data.get('ts')
+    
+def get_reminder_block(acronym, team_domain, approver, channel, ts):
+    return {
+		"blocks": [
+		    {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "You have one pending request for the acronym: *"+acronym+"*. Please click the link below to approve or deny."
                 }
-                approver_messages.append(message_data)
-
-        else:
-            print("Skip approver due to approver sent acronym request")
-
-    table.update_item(
-        Key={
-            'Acronym': acronym
-        },
-        UpdateExpression=f"set ApproverMessages=:a",
-        ExpressionAttributeValues={
-            ':a': approver_messages,
-        },
-        ReturnValues="UPDATED_NEW"
-    )
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "<https://"+team_domain+".slack.com/archives/"+channel+"/p"+ts.replace(".","")+">"
+                }
+            }
+        ],
+		"channel": approver
+    }
 
 def lambda_handler(event, context):
 
     results = table.query(IndexName="approval_index", KeyConditionExpression=Key("Approval").eq('pending'))
-
     if len(results['Items']) > 0:
         items = results['Items']
-
         for item in items:
             request_time = float(item.get(REQUEST_TIMESTAMP))
             current_time = float(datetime.utcnow().timestamp())
-            # Change to TO_DAYS
-            diff_time  = (current_time - request_time)//TO_MINUTES
-
+            diff_time  = (current_time - request_time)//TO_DAYS
             acronym = item.get('Acronym')
-            print(acronym)
-            definition = item.get('Definition')
-            meaning = item.get('Meaning')
-            notes = item.get('Notes')
-            user_id = item.get('Requester')
-            user_name = item.get('RequesterName')
-            team_domain = item.get('TeamDomain')
-            approvers_with_answer = item.get(APPROVERS_STR, []) + item.get(DENIERS_STR, [])
 
-            # Change to 30 
-            if diff_time == 1:
-                send_reminder(acronym, definition, meaning, notes, user_id, user_name, team_domain, approvers_with_answer)
-            # Change to 60
-            elif diff_time == 2:
+            if diff_time == 30:
+                send_reminder(item)
+            elif diff_time == 60:
                 update_form_closed(item)
                 response = table.delete_item(
                     Key={

--- a/lambda/send_reminder.py
+++ b/lambda/send_reminder.py
@@ -1,0 +1,32 @@
+import boto3
+import os
+from datetime import datetime
+
+# Get the service resource.
+dynamodb = boto3.resource('dynamodb')
+table_name = os.environ['TABLE_NAME']
+table = dynamodb.Table(table_name)
+
+TO_MINUTES = 1000*60
+REQUEST_TIMESTAMP = 'RequestTimestamp'
+SENT_REMINDERS = 'Reminders'
+
+def send_reminder(event):
+    return
+
+def lambda_handler(event, context):
+
+    results = table.query(KeyConditionExpression=Key("Approval").eq('pending'))
+    if len(results['Items']) > 0:
+    items = results['Items']
+
+    for item in items:
+        print(item.get('Acronym'))
+        request_time = item.get(REQUEST_TIMESTAMP)/TO_MINUTES
+        current_time = datetime.utcnow().timestamp()/TO_MINUTES
+
+        """
+        if current_time - request_time > 10 and item.get(SENT_REMINDERS) == 0:
+            send_reminder()
+        """
+

--- a/lambda/send_reminder.py
+++ b/lambda/send_reminder.py
@@ -18,6 +18,7 @@ table = dynamodb.Table(table_name)
 APPROVERS = os.environ['APPROVERS'].split(',')
 OAUTH_TOKEN = os.environ['OAUTH_TOKEN']
 
+# Change to TO_DAYS = 60*60*24
 TO_MINUTES = 60
 REQUEST_TIMESTAMP = 'RequestTimestamp'
 APPROVERS_STR = 'Approvers'
@@ -86,6 +87,7 @@ def lambda_handler(event, context):
         for item in items:
             request_time = float(item.get(REQUEST_TIMESTAMP))
             current_time = float(datetime.utcnow().timestamp())
+            # Change to TO_DAYS
             diff_time  = (current_time - request_time)//TO_MINUTES
 
             acronym = item.get('Acronym')
@@ -98,8 +100,10 @@ def lambda_handler(event, context):
             team_domain = item.get('TeamDomain')
             approvers_with_answer = item.get(APPROVERS_STR, []) + item.get(DENIERS_STR, [])
 
+            # Change to 30 
             if diff_time == 1:
                 send_reminder(acronym, definition, meaning, notes, user_id, user_name, team_domain, approvers_with_answer)
+            # Change to 60
             elif diff_time == 2:
                 update_form_closed(item)
                 response = table.delete_item(


### PR DESCRIPTION
Send 30 day reminder and delete item after 60 days. 
This PR adds a new lambda function triggered by CloudWatch. To do so we add a new CloudWatch stack that runs an event on a schedule (each minute for testing purposes and should be changed to each day for final deployment). 
Also, a new global secondary index is added in order to query the table depending on the approval status.

The new lambda function will compare the request date and the current time to decide if it'll send the reminder or if it will delete it